### PR TITLE
chore: add openai api key to .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 /backend/src/main/resources/rebell-works-llm-firebase-adminsdk-fbsvc-575eea3fcf.json
+/.env

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -58,6 +58,13 @@
             <version>9.3.0</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.json/json -->
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20231013</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/backend/src/main/java/example/GptTest.java
+++ b/backend/src/main/java/example/GptTest.java
@@ -1,0 +1,54 @@
+package example;
+
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+// Example of how to use the openai API.
+public class GptTest {
+
+    public static void main(String[] args) throws IOException, URISyntaxException {
+        String apiKey = System.getenv("OPENAI_API_KEY");
+        String url = "https://api.openai.com/v1/responses";
+        String body = """
+                {
+                    "model": "gpt-4o",
+                    "input": [
+                        {
+                            "role": "user",
+                            "content": "As a student, I am looking for a job. I am motivated and have experience in software development. Please provide 1 job option in brief advice, one sentence max!"
+                        }
+                    ]
+                }""";
+
+        try (HttpClient client = HttpClient.newHttpClient()) {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer " + apiKey)
+                    .POST(HttpRequest.BodyPublishers.ofString(body))
+                    .build();
+
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+//            System.out.println("Response: " + response.body());
+            JSONObject jsonResponse = new JSONObject(response.body());
+//            System.out.println("JSON Response: " + jsonResponse);
+            String content = jsonResponse
+                    .getJSONArray("output")
+                    .getJSONObject(0)
+                    .getJSONArray("content")
+                    .getJSONObject(0)
+                    .getString("text");
+
+            System.out.println("API Response: " + content);
+
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
chore: add openai api key to .env

- Ignored real .env, added .env.example for info.

feat(test): add open ai gpt request example

- GptTest contains example on how to use the openai API.