### PR TITLE
Refactor existing matching to implement match engine interface

### DIFF
--- a/backend/src/main/java/com/rebellworksllm/backend/matching/application/CosSimMatchEngine.java
+++ b/backend/src/main/java/com/rebellworksllm/backend/matching/application/CosSimMatchEngine.java
@@ -1,0 +1,28 @@
+package com.rebellworksllm.backend.matching.application;
+
+import com.rebellworksllm.backend.matching.domain.*;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+public class CosSimMatchEngine implements MatchEngine {
+
+    private final StudentJobMatchingService matchingService;
+    private final VacancyService vacancyService;
+
+    public CosSimMatchEngine(StudentJobMatchingService matchingService, VacancyService vacancyService) {
+        this.matchingService = matchingService;
+        this.vacancyService = vacancyService;
+    }
+
+    @Override
+    public List<StudentVacancyMatch> query(Student student, int amount) {
+
+        List<Vacancy> vacancies = vacancyService.getAllVacancies();
+        List<StudentVacancyMatch> matches = matchingService.findBestMatches(student, vacancies, amount);
+
+        return Collections.unmodifiableList(matches);
+    }
+}

--- a/backend/src/main/java/com/rebellworksllm/backend/matching/application/HubSpotWebhookService.java
+++ b/backend/src/main/java/com/rebellworksllm/backend/matching/application/HubSpotWebhookService.java
@@ -15,42 +15,41 @@ public class HubSpotWebhookService {
 
     private static final int FIRST_MATCH_LIMIT = 5;
 
+    private final MatchEngine matchEngine;
     private final HubSpotStudentService studentService;
-    private final VacancyService vacancyService;
     private final OpenAIEmbeddingService embeddingService;
-    private final StudentJobMatchingService matchingService;
     private final WhatsAppService whatsAppService;
 
-    public HubSpotWebhookService(HubSpotStudentService studentService,
-                                 VacancyService vacancyService,
+    public HubSpotWebhookService(MatchEngine matchEngine,
+                                 HubSpotStudentService studentService,
                                  OpenAIEmbeddingService embeddingService,
-                                 StudentJobMatchingService matchingService,
                                  WhatsAppService whatsAppService
     ) {
+        this.matchEngine = matchEngine;
         this.studentService = studentService;
-        this.vacancyService = vacancyService;
         this.embeddingService = embeddingService;
-        this.matchingService = matchingService;
         this.whatsAppService = whatsAppService;
     }
 
+    public void processStudentMatch(long id) {
+        StudentContact studentContact = studentService.getStudentById(id);
+        Student student = toStudent(studentContact);
 
-    public void startMatchEventForObject(long objectId) {
-        StudentContact studentContact = studentService.getStudentById(objectId);
+        List<StudentVacancyMatch> matches = matchEngine.query(student, FIRST_MATCH_LIMIT);
 
-        Student realStudent = toStudent(studentContact);
-        List<Vacancy> vacancies = vacancyService.getAllVacancies();
-        List<StudentVacancyMatch> matches = matchingService.findBestMatches(realStudent, vacancies, FIRST_MATCH_LIMIT);
-
-        whatsAppService.sendWithVacancyTemplate(
-                studentContact.phoneNumber(),
-                studentContact.fullName(),
-                matches.getFirst().vacancy().website(),
-                matches.get(0).vacancy().website(),
-                matches.get(1).vacancy().website(),
-                matches.get(2).vacancy().website(),
-                matches.get(3).vacancy().website()
-        );
+        try {
+            whatsAppService.sendWithVacancyTemplate(
+                    studentContact.phoneNumber(),
+                    studentContact.fullName(),
+                    matches.getFirst().vacancy().website(),
+                    matches.get(0).vacancy().website(),
+                    matches.get(1).vacancy().website(),
+                    matches.get(2).vacancy().website(),
+                    matches.get(3).vacancy().website()
+            );
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private Student toStudent(StudentContact studentContact) {

--- a/backend/src/main/java/com/rebellworksllm/backend/matching/application/MatchEngine.java
+++ b/backend/src/main/java/com/rebellworksllm/backend/matching/application/MatchEngine.java
@@ -1,0 +1,11 @@
+package com.rebellworksllm.backend.matching.application;
+
+import com.rebellworksllm.backend.matching.domain.Student;
+import com.rebellworksllm.backend.matching.domain.StudentVacancyMatch;
+
+import java.util.List;
+
+public interface MatchEngine {
+
+    List<StudentVacancyMatch> query(Student student, int amount);
+}

--- a/backend/src/main/java/com/rebellworksllm/backend/matching/presentation/HubSpotWebhookController.java
+++ b/backend/src/main/java/com/rebellworksllm/backend/matching/presentation/HubSpotWebhookController.java
@@ -21,7 +21,7 @@ public class HubSpotWebhookController {
 
     @PostMapping("/created")
     public ResponseEntity<HubSpotWebhookResponse> handleContactCreation(@Valid @RequestBody HubSpotWebhookPayload payload) {
-        webhookService.startMatchEventForObject(payload.objectId());
+        webhookService.processStudentMatch(payload.objectId());
         HubSpotWebhookResponse response = new HubSpotWebhookResponse(
                 HttpStatus.OK.value(),
                 "StudentContact matched successfully"


### PR DESCRIPTION
Fetching vacancies and matching a student to vacancies is now decoupled into its own match engine interface implementation. This ensures additional engines, like Pinecone, can be easily implemented and switched.