### PR TITLE
feat: enhance phone search in HubSpot and update log paths

### DIFF
--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -2,10 +2,10 @@
 
     <!-- BACKEND FILE APPENDER -->
     <appender name="BACKEND_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>backend/logs/matching.log</file>
+        <file>logs/matching.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>backend/logs/matching.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <fileNamePattern>logs/matching.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <maxFileSize>50MB</maxFileSize>
             <maxHistory>30</maxHistory>
             <totalSizeCap>2GB</totalSizeCap>
@@ -23,10 +23,10 @@
 
     <!-- SECURITY FILE APPENDER -->
     <appender name="SECURITY_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>backend/logs/security.log</file>
+        <file>logs/security.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <fileNamePattern>backend/logs/security.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <fileNamePattern>logs/security.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <maxFileSize>50MB</maxFileSize>
             <maxHistory>30</maxHistory>
             <totalSizeCap>1GB</totalSizeCap>


### PR DESCRIPTION
- Introduced `createPhoneVariants` for flexible phone number matching in HubSpot search.
- Replaced `"CONTAINS_TOKEN"` operator with `"IN"` for improved filtering.
- Updated log paths in `logback-spring.xml` to remove `backend/` prefix.