### PR TITLE
feat: normalize and validate phone numbers in matching workflows

### DIFF
--- a/backend/src/main/java/com/rebellworksllm/backend/modules/hubspot/data/HubSpotStudentService.java
+++ b/backend/src/main/java/com/rebellworksllm/backend/modules/hubspot/data/HubSpotStudentService.java
@@ -4,6 +4,7 @@ import com.rebellworksllm.backend.common.utils.LogUtils;
 import com.rebellworksllm.backend.modules.hubspot.application.exception.HubSpotStudentNotFoundException;
 import com.rebellworksllm.backend.modules.hubspot.application.dto.StudentContact;
 import com.rebellworksllm.backend.modules.hubspot.config.HubSpotCredentials;
+import com.rebellworksllm.backend.modules.matching.application.util.MatchingUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -74,7 +75,7 @@ public class HubSpotStudentService {
                 .path("/crm/v3/objects/contacts/search")
                 .toUriString();
 
-        List<String> phoneVariants = createPhoneVariants(phone);
+        List<String> phoneVariants = MatchingUtils.createDutchPhoneVariantsForHubSpot(phone);
 
         Map<String, Object> searchRequest = Map.of(
                 "filterGroups", List.of(Map.of(
@@ -139,19 +140,5 @@ public class HubSpotStudentService {
                 props.getOrDefault("location", ""),
                 props.getOrDefault("geboortedatum", "")
         );
-    }
-
-    private List<String> createPhoneVariants(String phone) {
-        String clean = phone.replaceAll("[\\s\\-()]", "");
-
-        if (clean.startsWith("+316")) {
-            return List.of(clean, "06" + clean.substring(4));
-        } else if (clean.startsWith("316")) {
-            return List.of("+" + clean, "06" + clean.substring(3));
-        } else if (clean.startsWith("06")) {
-            return List.of(clean, "+316" + clean.substring(2));
-        }
-
-        return List.of(clean);
     }
 }

--- a/backend/src/main/java/com/rebellworksllm/backend/modules/matching/application/util/MatchingUtils.java
+++ b/backend/src/main/java/com/rebellworksllm/backend/modules/matching/application/util/MatchingUtils.java
@@ -1,5 +1,10 @@
 package com.rebellworksllm.backend.modules.matching.application.util;
 
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
 public class MatchingUtils {
 
     private MatchingUtils() {
@@ -7,6 +12,40 @@ public class MatchingUtils {
 
     public static String normalizePhone(String phone) {
         if (phone == null) return null;
-        return phone.replace("+", "");
+
+        // keep digits only
+        String digits = phone.replaceAll("\\D", "");
+
+        if (digits.isBlank()) return null;
+
+        // 0031... => 31...
+        if (digits.startsWith("0031")) {
+            digits = "31" + digits.substring(4);
+        }
+
+        // 06... (or other 0...) => 31...
+        if (digits.startsWith("0") && digits.length() > 1) {
+            digits = "31" + digits.substring(1);
+        }
+
+        return digits;
+    }
+
+    public static List<String> createDutchPhoneVariantsForHubSpot(String phone) {
+        String normalized = normalizePhone(phone);
+        if (normalized == null) return List.of();
+
+        Set<String> variants = new LinkedHashSet<>();
+
+        // Always include international forms
+        variants.add(normalized);         // 31...
+        variants.add("+" + normalized);   // +31...
+
+        // If it's Dutch mobile (316...), also include local 06...
+        if (normalized.startsWith("316") && normalized.length() > 3) {
+            variants.add("06" + normalized.substring(3));
+        }
+
+        return new ArrayList<>(variants);
     }
 }


### PR DESCRIPTION
- Added `MatchingUtils.normalizePhone` for consistent phone number formatting.
- Updated `MatchMessageRepositoryImpl` to validate and normalize phone numbers before saving or fetching.
- Introduced `createDutchPhoneVariantsForHubSpot` for generating phone number variants.
- Replaced hardcoded phone variant logic in `HubSpotStudentService` with utility method for reuse and clarity.